### PR TITLE
fix: remove baseUrl, use relative imports

### DIFF
--- a/src/YagrCore/plugins/plotLines/plotLines.ts
+++ b/src/YagrCore/plugins/plotLines/plotLines.ts
@@ -1,9 +1,8 @@
 import type Yagr from '../../';
 import UPlot, {Plugin} from 'uplot';
 import {DEFAULT_X_SCALE, DEFAULT_CANVAS_PIXEL_RATIO} from '../../defaults';
-import {PLineConfig, PlotLineConfig, YagrPlugin} from '../../types';
+import {PBandConfig, PLineConfig, PlotLineConfig, YagrPlugin} from '../../types';
 import {DrawOrderKey} from '../../utils/types';
-import {PBandConfig} from 'src/types';
 import {deepIsEqual, genId} from '../../utils/common';
 import {calculateFromTo} from './utils';
 

--- a/src/YagrCore/plugins/tooltip/types.ts
+++ b/src/YagrCore/plugins/tooltip/types.ts
@@ -1,6 +1,6 @@
 import {AlignedData} from 'uplot';
 import Yagr from '../../index';
-import {ProcessingInterpolation} from 'src/types';
+import {ProcessingInterpolation} from '../../types';
 
 export type CustomTrackingFunctionOptions = {
     x: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
         "experimentalDecorators": true,
         "allowJs": false,
         "jsx": "react",
-        "baseUrl": ".",
         "outDir": "./dist"
     },
     "include": ["./src", "./typings", "./node_modules/uplot/dist/uPlot.d.ts"]


### PR DESCRIPTION
`baseUrl` lets TS resolve non-relative imports relative to it, but tsc does not rewrite these paths in emitted `.d.ts` files, breaking type resolution for consumers.